### PR TITLE
[#19] 메모 작성 뷰 레이아웃 구현

### DIFF
--- a/SeSAC-Memo/SeSAC-Memo.xcodeproj/project.pbxproj
+++ b/SeSAC-Memo/SeSAC-Memo.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		BD96C5DE28C37158000621E6 /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD96C5DD28C37158000621E6 /* Int+.swift */; };
 		BD96C5E028C38584000621E6 /* DateFormatType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD96C5DF28C38584000621E6 /* DateFormatType.swift */; };
 		BD96C5E228C397C9000621E6 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD96C5E128C397C9000621E6 /* Date+.swift */; };
+		BD96C5E728C3B4DE000621E6 /* MemoWriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD96C5E628C3B4DE000621E6 /* MemoWriteView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +71,7 @@
 		BD96C5DD28C37158000621E6 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		BD96C5DF28C38584000621E6 /* DateFormatType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatType.swift; sourceTree = "<group>"; };
 		BD96C5E128C397C9000621E6 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
+		BD96C5E628C3B4DE000621E6 /* MemoWriteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoWriteView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +210,7 @@
 			isa = PBXGroup;
 			children = (
 				BD69ED0C28C0A01300D62240 /* MemoWriteViewController.swift */,
+				BD96C5E528C3B4D6000621E6 /* View */,
 			);
 			path = MemoWrite;
 			sourceTree = "<group>";
@@ -264,6 +267,14 @@
 				BD96C5E128C397C9000621E6 /* Date+.swift */,
 			);
 			path = "Foundation+";
+			sourceTree = "<group>";
+		};
+		BD96C5E528C3B4D6000621E6 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				BD96C5E628C3B4DE000621E6 /* MemoWriteView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -385,6 +396,7 @@
 				BD69ED0D28C0A01300D62240 /* MemoWriteViewController.swift in Sources */,
 				BD45B02E28C1157C00C271AA /* MemoCell.swift in Sources */,
 				BD69ED1D28C0A48000D62240 /* Memo.swift in Sources */,
+				BD96C5E728C3B4DE000621E6 /* MemoWriteView.swift in Sources */,
 				BD96C5E228C397C9000621E6 /* Date+.swift in Sources */,
 				BD69ED3928C0FA0100D62240 /* PopUpView.swift in Sources */,
 				BD96C5DE28C37158000621E6 /* Int+.swift in Sources */,

--- a/SeSAC-Memo/SeSAC-Memo/Presentation/MemoWrite/MemoWriteViewController.swift
+++ b/SeSAC-Memo/SeSAC-Memo/Presentation/MemoWrite/MemoWriteViewController.swift
@@ -9,7 +9,25 @@ import UIKit
 
 final class MemoWriteViewController: UIViewController {
     
+    private let rootView = MemoWriteView()
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        configureNavigationBar()
+    }
+}
+
+extension MemoWriteViewController {
+    
+    private func configureNavigationBar() {
+        let doneItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: nil)
+        let shareItem = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"), style: .plain, target: self, action: nil)
+        navigationController?.navigationBar.tintColor = ColorFactory.shared.create(.primary)
+        navigationItem.rightBarButtonItems = [doneItem, shareItem]
     }
 }

--- a/SeSAC-Memo/SeSAC-Memo/Presentation/MemoWrite/View/MemoWriteView.swift
+++ b/SeSAC-Memo/SeSAC-Memo/Presentation/MemoWrite/View/MemoWriteView.swift
@@ -1,0 +1,76 @@
+//
+//  MemoWriteView.swift
+//  SeSAC-Memo
+//
+//  Created by taekki on 2022/09/04.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class MemoWriteView: BaseView {
+    
+    private let scrollView = UIScrollView()
+    private lazy var containerStackView = UIStackView(arrangedSubviews: [titleTextView, contentTextView])
+    let titleTextView = UITextView()
+    let contentTextView = UITextView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureTextView()
+    }
+    
+    override func configureAttributes() {
+        containerStackView.do {
+            $0.axis = .vertical
+        }
+        
+        titleTextView.do {
+            $0.becomeFirstResponder()
+            $0.textColor = .label
+            $0.font = .boldSystemFont(ofSize: 22)
+            $0.isScrollEnabled = false
+        }
+        
+        contentTextView.do {
+            $0.textColor = .label
+            $0.font = .systemFont(ofSize: 17)
+            $0.isScrollEnabled = false
+        }
+    }
+    
+    override func configureLayout() {
+        addSubviews(scrollView)
+        scrollView.addSubview(containerStackView)
+        
+        scrollView.snp.makeConstraints {
+            $0.top.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.trailing.leading.equalToSuperview().inset(16)
+        }
+        
+        containerStackView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.trailing.leading.equalToSuperview()
+            $0.width.equalToSuperview()
+        }
+    }
+}
+
+extension MemoWriteView: UITextViewDelegate {
+    
+    private func configureTextView() {
+        titleTextView.delegate = self
+        contentTextView.delegate = self
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if text == "\n" && textView == titleTextView {
+            textView.resignFirstResponder()
+            contentTextView.becomeFirstResponder()
+        }
+        return true
+    }
+}


### PR DESCRIPTION
## 📕 Issue

fix #19

## 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 메모 작성 뷰 네비게이션 바 설정
- [x] 메모 작성 뷰 레이아웃 구현
  - [x] TextView(title, content) 영역 구분
  - [x] 작성 뷰에 진입하면 titleTextView에 FirstResponder를 할당합니다.
  - [x] Enter를 입력하면 contentTextView로 responder를 할당합니다.

## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

## 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 사용자 가이드 업데이트가 필요한가?
  - [ ] 사용자 가이드를 업데이트 하였는가?
